### PR TITLE
bugfix: panicking when mobile random option falls into ios.firefox

### DIFF
--- a/cloudscraper/browsers.go
+++ b/cloudscraper/browsers.go
@@ -55,8 +55,10 @@ func getUserAgents(mobile bool) (BrowserConf, error) {
 	rnd := rand.Intn(len(osList))
 	pickedOs := userAgents[osList[rnd]]
 	var browserList []string
-	for k := range pickedOs {
-		browserList = append(browserList, k)
+	for k, v := range pickedOs {
+		if len(v) > 0 {
+			browserList = append(browserList, k)
+		}
 	}
 	rnd = rand.Intn(len(browserList))
 	browserName := browserList[rnd]


### PR DESCRIPTION
## Description:
When using mobile option in **Init** function, if it falls into ios->firefox, its slice is always empty, so rand.Intn will always generate 0, causing an index out of range.

## Fix:
First, checks if browser list is not empty during for loop iteration before appending it to **browserList** slice.